### PR TITLE
fix: get domain error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,16 @@ const fetch = window.fetch.bind(window);
 
 function getDomain(url) {
 	try {
+		// case url = "https://a.bbb.com/cc/dd/ee/1.0.2/index.html
 		// URL 构造函数不支持使用 // 前缀的 url
 		const href = new URL(url.startsWith('//') ? `${location.protocol}${url}` : url);
-		return href.origin;
+		const url = href.origin + href.pathname;
+		let domain;
+		if (url.endsWith('html') || url.endsWith('htm')) {
+			const index = url.lastIndexOf('/');
+			domain = url.substring(0, index + 1);
+		}
+		return domain || href.origin;
 	} catch (e) {
 		return '';
 	}


### PR DESCRIPTION
case url : `https://a.bbb.com/cc/dd/ee/1.0.2/index.html`
之前 `https://a.bbb.com`
修复后` https://a.bbb.com/cc/dd/ee/1.0.2/`

原因 
比如JS地址在HTML中为 `./static/js/main.a4cd3034.js`
之前 会变为 `https://a.bbb.com/static/js/main.a4cd3034.js`;
实际地址 ` https://a.bbb.com/cc/dd/ee/1.0.2/static/js/main.a4cd3034.js`

为何多保留一个 斜杠
避免有些地址直接为 `static/js/main.a4cd3034.js`