### PR TITLE
fix: 当script为空数组时,Promise没有resolve

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,9 @@ export function getExternalScripts(scripts, fetch = defaultFetch) {
 export function execScripts(entry, scripts, proxy = window, opts = {}) {
 	const { fetch = defaultFetch } = opts;
 
+	if(scripts.length === 0){
+		return Promise.resolve({});
+	}
 	return getExternalScripts(scripts, fetch)
 		.then(scriptsText => {
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7414171/70125749-67390000-16b2-11ea-871e-17d4bf197a61.png)

场景：
当加载纯静态页面时会有promise没有resolve的情况,主框架会一直在loading