### PR TITLE
feat: support of module scripts

### DIFF
--- a/src/__tests__/test-process-tpl.js
+++ b/src/__tests__/test-process-tpl.js
@@ -31,6 +31,14 @@ test('test process-tpl', () => {
 		'  crossorigin="anonymous"' +
 		'></script>' +
 		'<script \n' +
+		'  src="/module-for-modern-browsers.js"\n' +
+		'  type="module"' +
+		'></script>' +
+		'<script \n' +
+		'  src="/no-module-for-legacy-browsers.js"\n' +
+		'  nomodule' +
+		'></script>' +
+		'<script \n' +
 		'  src="/test-async.js"\n' +
 		'  async' +
 		'></script>' +
@@ -64,6 +72,9 @@ test('test process-tpl', () => {
 		'<script \n data-test>\n  window.routerBase = "/";\n</script>',
 		'//gw.alipayobjects.com/as/g/antcloud-fe/antd-cloud-nav/0.2.22/antd-cloud-nav.min.js',
 		'https://gw.alipayobjects.com/os/lib/react/16.8.6/umd/react.production.min.js',
+		// Jest/jsdom doesn't support module scripts, so nomodule scripts will be imported in test cases.
+		// https://github.com/jsdom/jsdom/issues/2475
+		'http://kuitos.me/no-module-for-legacy-browsers.js',
 		{
 			async: true,
 			src: 'http://kuitos.me/test-async.js',

--- a/src/process-tpl.js
+++ b/src/process-tpl.js
@@ -3,13 +3,15 @@
  * @homepage https://github.com/kuitos/
  * @since 2018-09-03 15:04
  */
-import { getInlineCode } from './utils';
+import { getInlineCode, isModuleScriptSupported } from './utils';
 
 const ALL_SCRIPT_REGEX = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi;
 const SCRIPT_TAG_REGEX = /<(script)\s+((?!type=('|')text\/ng-template\3).)*?>.*?<\/\1>/is;
 const SCRIPT_SRC_REGEX = /.*\ssrc=('|")?([^>'"\s]+)/;
 const SCRIPT_ENTRY_REGEX = /.*\sentry\s*.*/;
 const SCRIPT_ASYNC_REGEX = /.*\sasync\s*.*/;
+const SCRIPT_NO_MODULE_REGEX = /.*\snomodule\s*.*/;
+const SCRIPT_MODULE_REGEX = /.*\stype=('|")?module('|")?\s*.*/;
 const LINK_TAG_REGEX = /<(link)\s+.*?>/gi;
 const LINK_IGNORE_REGEX = /.*ignore\s*.*/;
 const LINK_PRELOAD_OR_PREFETCH_REGEX = /\srel=('|")?(preload|prefetch)\1/;
@@ -33,6 +35,7 @@ export const genLinkReplaceSymbol = (linkHref, preloadOrPrefetch = false) => `<!
 export const genScriptReplaceSymbol = (scriptSrc, async = false) => `<!-- ${async ? 'async' : ''} script ${scriptSrc} replaced by import-html-entry -->`;
 export const inlineScriptReplaceSymbol = `<!-- inline scripts replaced by import-html-entry -->`;
 export const genIgnoreAssetReplaceSymbol = url => `<!-- ignore asset ${url || 'file'} replaced by import-html-entry -->`;
+export const genModuleScriptReplaceSymbol = (moduleSupport) => `<!-- ${moduleSupport ? 'nomodule' : 'module'} script ignored by import-html-entry -->`;
 
 /**
  * parse the script link from the template
@@ -50,6 +53,7 @@ export default function processTpl(tpl, baseURI) {
 	let scripts = [];
 	const styles = [];
 	let entry = null;
+	const moduleSupport = isModuleScriptSupported();
 
 	const template = tpl
 
@@ -102,6 +106,12 @@ export default function processTpl(tpl, baseURI) {
 		.replace(ALL_SCRIPT_REGEX, match => {
 			const scriptIgnore = match.match(SCRIPT_IGNORE_REGEX);
 			// in order to keep the exec order of all javascripts
+
+			if (moduleSupport && match.match(SCRIPT_NO_MODULE_REGEX)) {
+				return genModuleScriptReplaceSymbol(moduleSupport);
+			} else if (!moduleSupport && match.match(SCRIPT_MODULE_REGEX)) {
+				return genModuleScriptReplaceSymbol(moduleSupport)
+			}
 
 			// if it is a external script
 			if (SCRIPT_TAG_REGEX.test(match) && match.match(SCRIPT_SRC_REGEX)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -95,6 +95,12 @@ export function defaultGetPublicPath(url) {
 	}
 }
 
+// Detect whether browser supports `<script type=module>` or not
+export function isModuleScriptSupported() {
+	const s = document.createElement('script');
+	return 'noModule' in s;
+}
+
 // RIC and shim for browsers setTimeout() without it
 export const requestIdleCallback =
 	window.requestIdleCallback ||


### PR DESCRIPTION
As mentioned in this feature request https://github.com/umijs/qiankun/issues/507, add support for `<script type=module>`(modern browsers) and `<script nomodule>`(legacy browsers).

FYI, JSDOM currently doesn't support this feature [due to lack of spec](https://github.com/jsdom/jsdom/issues/2475), so expected behavior in test cases should be same as legacy browsers.


resolve https://github.com/umijs/qiankun/issues/507