### PR TITLE
去掉sourceURL注释中的\n \r\n

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,8 @@ function getExecutableScript(scriptSrc, scriptText, proxy, strictGlobal) {
 	window.proxy = proxy;
 	// TODO 通过 strictGlobal 方式切换切换 with 闭包，待 with 方式坑趟平后再合并
 	return strictGlobal
-		? `;(function(window, self){with(window){;${scriptText}\n//# sourceURL=${scriptSrc}\n}}).bind(window.proxy)(window.proxy, window.proxy);`
-		: `;(function(window, self){;${scriptText}\n//# sourceURL=${scriptSrc}\n}).bind(window.proxy)(window.proxy, window.proxy);`;
+		? `;(function(window, self){with(window){;${scriptText}\n//# sourceURL=${scriptSrc.replace(/\n|\r\n/g,'')}\n}}).bind(window.proxy)(window.proxy, window.proxy);`
+		: `;(function(window, self){;${scriptText}\n//# sourceURL=${scriptSrc.replace(/\n|\r\n/g,'')}\n}).bind(window.proxy)(window.proxy, window.proxy);`;
 }
 
 // for prefetch


### PR DESCRIPTION
当inlineScript未被压缩时会存在换行符，此时注释只会注掉第一行，导致程序报错