### PR TITLE
feat(utils.js): replace for-in with Object.keys in noteGlobalProps()

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -62,15 +62,17 @@ export function noteGlobalProps(global) {
 	// but this may be faster (pending benchmarks)
 	firstGlobalProp = secondGlobalProp = undefined;
 
-	for (let p in global) {
-		if (shouldSkipProperty(global, p))
-			continue;
-		if (!firstGlobalProp)
-			firstGlobalProp = p;
-		else if (!secondGlobalProp)
-			secondGlobalProp = p;
-		lastGlobalProp = p;
-	}
+	Object
+		.keys(global)
+		.forEach((p) => {
+			if (!shouldSkipProperty(global, p))
+				return;
+			if (!firstGlobalProp)
+				firstGlobalProp = p;
+			else if (!secondGlobalProp)
+				secondGlobalProp = p;
+			lastGlobalProp = p;
+		});
 
 	return lastGlobalProp;
 }


### PR DESCRIPTION
### 实现方案
1. 使用 for-in
```js
for (let i = 0; i < 1000; i++) {
  for (let p in window) {
    if (!shouldSkipProperty(window, p)) continue
    if (!firstGlobalProp)
      firstGlobalProp = p
    else if (!secondGlobalProp)
      secondGlobalProp = p
    lastGlobalProp = p
  }
}
```
    
2. 使用 Object.keys
```js
Object
  .keys(window)
  .forEach((p) => {
    if (!shouldSkipProperty(window, p)) return
    if (!firstGlobalProp)
      firstGlobalProp = p
    else if (!secondGlobalProp)
      secondGlobalProp = p
    lastGlobalProp = p
  })
```
3. 使用 Object.keys获取keys，然后基于传统 for-loop 遍历
```js
let p
for(let i = 0, keys = Object.keys(window), len = keys.length; i < len; i++) {
  p = keys[i]
  if (!shouldSkipProperty(window, p)) continue
  if (!firstGlobalProp)
    firstGlobalProp = p
  else if (!secondGlobalProp)
    secondGlobalProp = p
  lastGlobalProp = p
}
```

### 用例：
3种实现方案分别对 window 进行1000遍历，并执行 firstGlobalProp、secondGlobalProp、lastGlobalProp 的赋值操作。

### 结果
![image](https://user-images.githubusercontent.com/20550888/96698597-e402c480-13bf-11eb-8926-1afc6ed4aa46.png)

- BenchMark用例详见：https://codepen.io/lqy455949477/pen/oNLzJBK

### 分析：
  1. 范围减小：for-in会遍历对象的属性和在 prototype 上的方法，基于 Chrome 86来看，总共遍历了237个属性(或方法)。而 Object.keys 仅遍历233个属性。
  2. global.hasOwnProperty()的运行效率：在遍历到 prototype 方法时，该API的性能会急剧下降。

### 遗留问题：
1. 方案3的性能相比方案2理论上会有一定的提升，因为没有通过 forEach 去多次调用某个函数。但实际测试下来，没有明显提升，甚至某些情况下性能会低于方案2，可能需要更多测试来验证。
