### PR TITLE
feat: beforeExec支持修改js代码 + 新增afterExec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.10.0 -- 2020/10/27
+- `beforeExec`支持传入`code, script`，如果返回值是非空string，那么将会替换掉原先的code
+- 新增每个js文件/inline script执行完毕之后的hook： `afterExec`，参数和`beforeExec`一样，但是无返回值

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,13 +19,16 @@ export type ImportEntryOpts = {
 	fetch?: typeof window.fetch;
 	getPublicPath?: (entry: Entry) => string;
 	getTemplate?: (tpl: string) => string;
+	// 每个脚本执行之前触发，如果返回的是非空string， 那么将把返回值替换code执行
+	beforeExec?: (code: string, script: string) => string | void;
+	// 每个脚本执行完毕后触发，如果脚本执行报错，那么就不会触发
+	afterExec?: (code: string, script: string) => void;
 }
 
-type ExecScriptsOpts = Pick<ImportEntryOpts, 'fetch'> & {
+type ExecScriptsOpts = Pick<ImportEntryOpts, 'fetch' | 'beforeExec' | 'afterExec'> & {
 	strictGlobal?: boolean;
 	success?: CallableFunction;
 	error?: CallableFunction;
-	beforeExec?: CallableFunction;
 }
 
 export type Entry = string | { styles?: string[], scripts?: string[], html?: string };

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ interface IImportResult {
 
 	assetPublicPath: string;
 
-	execScripts<T>(sandbox?: object, strictGlobal?: boolean): Promise<T>;
+	execScripts<T>(sandbox?: object, strictGlobal?: boolean, execScriptsHooks?: ExecScriptsHooks): Promise<T>;
 
 	getExternalScripts(): Promise<string[]>;
 
@@ -19,13 +19,16 @@ export type ImportEntryOpts = {
 	fetch?: typeof window.fetch;
 	getPublicPath?: (entry: Entry) => string;
 	getTemplate?: (tpl: string) => string;
+}
+
+export type ExecScriptsHooks = {
 	// 每个脚本执行之前触发，如果返回的是非空string， 那么将把返回值替换code执行
 	beforeExec?: (code: string, script: string) => string | void;
 	// 每个脚本执行完毕后触发，如果脚本执行报错，那么就不会触发
 	afterExec?: (code: string, script: string) => void;
 }
 
-type ExecScriptsOpts = Pick<ImportEntryOpts, 'fetch' | 'beforeExec' | 'afterExec'> & {
+type ExecScriptsOpts = Pick<ImportEntryOpts, 'fetch'> & ExecScriptsHooks & {
 	strictGlobal?: boolean;
 	success?: CallableFunction;
 	error?: CallableFunction;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import-html-entry",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "import html and get the exports of entry",
   "main": "./lib/index.js",
   "module": "./esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import-html-entry",
-  "version": "1.10.0",
+  "version": "1.9.3",
   "description": "import html and get the exports of entry",
   "main": "./lib/index.js",
   "module": "./esm/index.js",

--- a/src/__tests__/test-exec-scripts.js
+++ b/src/__tests__/test-exec-scripts.js
@@ -162,17 +162,18 @@ describe('execScripts', () => {
 				'./dummy.html',
 				{
 					fetch,
-					beforeExec(code, scriptSource) {
-						expect(code).toBe(expectCode);
-						expect(scriptSource).toBe(script);
-
-						return 'console.log("updated")';
-					},
-					afterExec: afterExecHook,
 				}
 			);
 
-			await result.execScripts(dummyContext, true);
+			await result.execScripts(dummyContext, true, {
+				beforeExec(code, scriptSource) {
+					expect(code).toBe(expectCode);
+					expect(scriptSource).toBe(script);
+
+					return 'console.log("updated")';
+				},
+				afterExec: afterExecHook,
+			});
 
 			// assert
 			expect(spyInstance).toHaveBeenCalledTimes(1);
@@ -209,17 +210,18 @@ describe('execScripts', () => {
 				},
 				{
 					fetch,
-					beforeExec(code, scriptSource) {
-						expect(code).toBe(expectCode);
-						expect(scriptSource).toBe(script);
-
-						return 'console.log(this.hello, window.hello, "updated")';
-					},
-					afterExec: afterExecHook,
 				}
 			);
 
-			await result.execScripts(dummyContext, true);
+			await result.execScripts(dummyContext, true, {
+				beforeExec(code, scriptSource) {
+					expect(code).toBe(expectCode);
+					expect(scriptSource).toBe(script);
+
+					return 'console.log(this.hello, window.hello, "updated")';
+				},
+				afterExec: afterExecHook,
+			});
 
 			// assert
 			expect(spyInstance).toHaveBeenCalledTimes(1);

--- a/src/__tests__/test-exec-scripts.js
+++ b/src/__tests__/test-exec-scripts.js
@@ -1,0 +1,232 @@
+import { execScripts, importEntry } from '../index';
+
+describe('execScripts', () => {
+	it('should support exec inline script correctly', async () => {
+		// arrange
+		const spyInstance = jest.spyOn(console, 'log');
+		spyInstance.mockImplementation(jest.fn());
+
+		const dummyContext = {
+			foo: 5,
+		};
+
+		try {
+			// act
+			await execScripts(
+				null,
+				['<script>console.log(this.foo, window.foo)</script>'],
+				dummyContext,
+			);
+
+			// assert
+			expect(spyInstance).toHaveBeenCalledTimes(1);
+			expect(spyInstance).toHaveBeenCalledWith(5, 5);
+		} finally {
+			spyInstance.mockRestore();
+		}
+	});
+
+	it('should support exec inline script with hooks correctly', async () => {
+		// arrange
+		const spyInstance = jest.spyOn(console, 'log');
+		spyInstance.mockImplementation(jest.fn());
+
+		const afterExecHook = jest.fn();
+
+		const dummyContext = {
+			hello: 'world',
+		};
+
+		const expectCode = 'console.log(this.foo, window.foo)';
+		const script = `<script>${expectCode}</script>`;
+
+		try {
+			// act
+			await execScripts(
+				null,
+				[script],
+				dummyContext,
+				{
+					beforeExec(code, scriptSource) {
+						expect(code).toBe(expectCode);
+						expect(scriptSource).toBe(script);
+
+						return 'console.log("updated")';
+					},
+					afterExec: afterExecHook,
+				}
+			);
+
+			// assert
+			expect(spyInstance).toHaveBeenCalledTimes(1);
+			expect(spyInstance).toHaveBeenCalledWith('updated');
+			expect(afterExecHook).toHaveBeenCalledWith(expectCode, script);
+		} finally {
+			spyInstance.mockRestore();
+		}
+	});
+
+	it('should support exec remote script correctly', async () => {
+		// arrange
+		const spyInstance = jest.spyOn(console, 'log');
+		spyInstance.mockImplementation(jest.fn());
+
+		const fetch = async () => ({
+			text: async () => 'console.log(window.foo)',
+		});
+
+		const dummyContext = {
+			foo: 6,
+		};
+
+		try {
+			// act
+			await execScripts(null, ['./foo.js'], dummyContext, {
+				fetch,
+			});
+
+			// assert
+			expect(spyInstance).toHaveBeenCalledTimes(1);
+			expect(spyInstance).toHaveBeenCalledWith(6);
+		} finally {
+			spyInstance.mockRestore();
+		}
+	});
+
+	it('should support exec remote script with hooks correctly', async () => {
+		// arrange
+		const spyInstance = jest.spyOn(console, 'log');
+		spyInstance.mockImplementation(jest.fn());
+
+		const afterExecHook = jest.fn();
+
+		const dummyContext = {
+			hello: 'world',
+		};
+
+		const expectCode = 'console.log(this.hello, window.hello)';
+		const script = './bar.js';
+
+		const fetch = async () => ({
+			text: async () => expectCode,
+		});
+
+		try {
+			// act
+			await execScripts(
+				null,
+				[script],
+				dummyContext,
+				{
+					fetch,
+					beforeExec(code, scriptSource) {
+						expect(code).toBe(expectCode);
+						expect(scriptSource).toBe(script);
+
+						return 'console.log("updated")';
+					},
+					afterExec: afterExecHook,
+				}
+			);
+
+			// assert
+			expect(spyInstance).toHaveBeenCalledTimes(1);
+			expect(spyInstance).toHaveBeenCalledWith('updated');
+			expect(afterExecHook).toHaveBeenCalledWith(expectCode, script);
+		} finally {
+			spyInstance.mockRestore();
+		}
+	});
+
+	it('should support exec script with importEntry correctly(html url)', async () => {
+		// arrange
+		const spyInstance = jest.spyOn(console, 'log');
+		spyInstance.mockImplementation(jest.fn());
+
+		const afterExecHook = jest.fn();
+
+		const dummyContext = {
+			hello: 'world',
+		};
+
+		const expectCode = 'console.log(this.hello, window.hello)';
+		const script = `<script>${expectCode}</script>`;
+
+		const fetch = async () => ({
+			text: async () => script,
+		});
+
+		try {
+			// act
+			const result = await importEntry(
+				'./dummy.html',
+				{
+					fetch,
+					beforeExec(code, scriptSource) {
+						expect(code).toBe(expectCode);
+						expect(scriptSource).toBe(script);
+
+						return 'console.log("updated")';
+					},
+					afterExec: afterExecHook,
+				}
+			);
+
+			await result.execScripts(dummyContext, true);
+
+			// assert
+			expect(spyInstance).toHaveBeenCalledTimes(1);
+			expect(spyInstance).toHaveBeenCalledWith('updated');
+			expect(afterExecHook).toHaveBeenCalledWith(expectCode, script);
+		} finally {
+			spyInstance.mockRestore();
+		}
+	});
+
+	it('should support exec script with importEntry correctly(html object)', async () => {
+		// arrange
+		const spyInstance = jest.spyOn(console, 'log');
+		spyInstance.mockImplementation(jest.fn());
+
+		const afterExecHook = jest.fn();
+
+		const dummyContext = {
+			hello: 'world',
+		};
+
+		const expectCode = 'console.log(this.hello, window.hello)';
+		const script = './html-object-script.js';
+
+		const fetch = async () => ({
+			text: async () => expectCode,
+		});
+
+		try {
+			// act
+			const result = await importEntry(
+				{
+					scripts: [script],
+				},
+				{
+					fetch,
+					beforeExec(code, scriptSource) {
+						expect(code).toBe(expectCode);
+						expect(scriptSource).toBe(script);
+
+						return 'console.log(this.hello, window.hello, "updated")';
+					},
+					afterExec: afterExecHook,
+				}
+			);
+
+			await result.execScripts(dummyContext, true);
+
+			// assert
+			expect(spyInstance).toHaveBeenCalledTimes(1);
+			expect(spyInstance).toHaveBeenCalledWith('world', 'world', 'updated');
+			expect(afterExecHook).toHaveBeenCalledWith(expectCode, script);
+		} finally {
+			spyInstance.mockRestore();
+		}
+	});
+});

--- a/src/index.js
+++ b/src/index.js
@@ -148,8 +148,8 @@ export function execScripts(entry, scripts, proxy = window, opts = {}) {
 		.then(scriptsText => {
 
 			const geval = (scriptSrc, inlineScript) => {
-				let code = beforeExec(inlineScript, scriptSrc) || inlineScript;
-				code = getExecutableScript(scriptSrc, code, proxy, strictGlobal);
+				const rawCode = beforeExec(inlineScript, scriptSrc) || inlineScript;
+				const code = getExecutableScript(scriptSrc, rawCode, proxy, strictGlobal);
 
 				(0, eval)(code);
 

--- a/src/index.js
+++ b/src/index.js
@@ -250,15 +250,15 @@ export default function importHTML(url, opts = {}) {
 				assetPublicPath,
 				getExternalScripts: () => getExternalScripts(scripts, fetch),
 				getExternalStyleSheets: () => getExternalStyleSheets(styles, fetch),
-				execScripts: (proxy, strictGlobal) => {
+				execScripts: (proxy, strictGlobal, execScriptsHooks = {}) => {
 					if (!scripts.length) {
 						return Promise.resolve();
 					}
 					return execScripts(entry, scripts, proxy, {
 						fetch,
 						strictGlobal,
-						beforeExec: opts.beforeExec,
-						afterExec: opts.afterExec,
+						beforeExec: execScriptsHooks.beforeExec,
+						afterExec: execScriptsHooks.afterExec,
 					});
 				},
 			}));
@@ -266,7 +266,7 @@ export default function importHTML(url, opts = {}) {
 }
 
 export function importEntry(entry, opts = {}) {
-	const { fetch = defaultFetch, getTemplate = defaultGetTemplate, beforeExec, afterExec } = opts;
+	const { fetch = defaultFetch, getTemplate = defaultGetTemplate } = opts;
 	const getPublicPath = opts.getPublicPath || opts.getDomain || defaultGetPublicPath;
 
 	if (!entry) {
@@ -279,8 +279,6 @@ export function importEntry(entry, opts = {}) {
 			fetch,
 			getPublicPath,
 			getTemplate,
-			beforeExec,
-			afterExec,
 		});
 	}
 
@@ -296,15 +294,15 @@ export function importEntry(entry, opts = {}) {
 			assetPublicPath: getPublicPath(entry),
 			getExternalScripts: () => getExternalScripts(scripts, fetch),
 			getExternalStyleSheets: () => getExternalStyleSheets(styles, fetch),
-			execScripts: (proxy, strictGlobal) => {
+			execScripts: (proxy, strictGlobal, execScriptsHooks = {}) => {
 				if (!scripts.length) {
 					return Promise.resolve();
 				}
 				return execScripts(scripts[scripts.length - 1], scripts, proxy, {
 					fetch,
 					strictGlobal,
-					beforeExec,
-					afterExec,
+					beforeExec: execScriptsHooks.beforeExec,
+					afterExec: execScriptsHooks.afterExec,
 				});
 			},
 		}));


### PR DESCRIPTION
新增beforeExec/afterExec，传入脚本上下文信息，从而支持多script同时执行下，支持正确设置document.currentScript

增加beforeExec修改代码能力，实现外部可控的代码执行