### PR TITLE
Fix an issue where import-html-entry is not able to load async ent…

### DIFF
--- a/src/__tests__/test-exec-scripts.js
+++ b/src/__tests__/test-exec-scripts.js
@@ -93,6 +93,39 @@ describe('execScripts', () => {
 		}
 	});
 
+	it('should support exec remote async entry script correctly', async () => {
+		// arrange
+		const spyInstance = jest.spyOn(console, 'log');
+		spyInstance.mockImplementation(jest.fn());
+
+		const fetch = async () => ({
+			text: async () => 'console.log(window.foo)',
+		});
+
+		const scriptObject = {
+			src: './foo.js',
+			async: true,
+			content: Promise.resolve()
+		};
+
+		const dummyContext = {
+			foo: 6,
+		};
+
+		try {
+			// act
+			await execScripts(scriptObject, [scriptObject], dummyContext, {
+				fetch,
+			});
+
+			// assert
+			expect(spyInstance).toHaveBeenCalledTimes(1);
+			expect(spyInstance).toHaveBeenCalledWith(6);
+		} finally {
+			spyInstance.mockRestore();
+		}
+	});
+
 	it('should support exec remote script with hooks correctly', async () => {
 		// arrange
 		const spyInstance = jest.spyOn(console, 'log');


### PR DESCRIPTION
As of right now, import-html-entry will throw an exception if the entry file has async attribute.

The issue can be reproduced with the unit test in the PR, the underlying problem is that script with attribute is being parsed as an project instead of a string, and because we are not check the script type for entry.

https://github.com/kuitos/import-html-entry/blob/6f4b5567663be54718a2cd7987417b95edf31c5a/src/index.js#L168-L180

The following line will throw an exception 

```
const isInlineCode = code => code.startsWith('<');
```

**Implementation Approach:**
Similar to how non-entry scripts are being handled, check the inlineScript type and retrieve JS content if it is an async script
