### PR TITLE
Feat: make execScripts consistent with browser's behaviors

### DIFF
--- a/src/__tests__/test-exec-scripts.js
+++ b/src/__tests__/test-exec-scripts.js
@@ -138,6 +138,39 @@ describe('execScripts', () => {
 		}
 	});
 
+	it('should support exec multiple scripts in right order', async () => {
+		const spyInstance = jest.spyOn(console, 'log');
+		spyInstance.mockImplementation(jest.fn());
+
+		const fetch = async () => ({
+			text: async () => 'window.foo = 2;',
+		});
+
+		const scripts = [
+			'./multiFoo.js',
+			'<script>window.foo = window.foo + window.bar</script>',
+			'<script>console.log(window.foo)</script>',
+		]
+
+		const dummyContext = {
+			foo: 6,
+			bar: 5
+		};
+
+		try {
+			// act
+			await execScripts(null, scripts, dummyContext, {
+				fetch,
+			});
+
+			// assert
+			expect(spyInstance).toHaveBeenCalledTimes(1);
+			expect(spyInstance).toHaveBeenCalledWith(7);
+		} finally {
+			spyInstance.mockRestore();
+		}
+	});
+	
 	it('should support exec script with importEntry correctly(html url)', async () => {
 		// arrange
 		const spyInstance = jest.spyOn(console, 'log');


### PR DESCRIPTION
I'm using qiankun in my company's projects and I found that scripts won't be executed until all scripts are loaded. It is not consistent with browsers' behaviors which is that each script would be executed immediately when it is loaded and all scripts before are executed. So I made some changes to the function execScripts. Now each script would be executed once it is ready.

The order of executing is ensured by the function canExec(index). And I didn't make changes to the funciton getExternalScripts since I don't know what would happen.

I have tried these changes in my own projects and they saved some time when qiankun download and execute scripts.

Looking forward to your response!