### PR TITLE
Optimize eval by cache the function of eval

### DIFF
--- a/src/__tests__/test-exec-scripts.js
+++ b/src/__tests__/test-exec-scripts.js
@@ -37,7 +37,7 @@ describe('execScripts', () => {
 			hello: 'world',
 		};
 
-		const expectCode = 'console.log(this.foo, window.foo)';
+		const expectCode = 'console.log("updated")';
 		const script = `<script>${expectCode}</script>`;
 
 		try {

--- a/src/__tests__/test-utils.js
+++ b/src/__tests__/test-utils.js
@@ -1,5 +1,5 @@
 import iconv from 'iconv-lite';
-import { defaultGetPublicPath, readResAsString } from '../utils';
+import { defaultGetPublicPath, readResAsString, evalCode } from '../utils';
 
 describe('utils', () => {
 	it('defaultGetPublicPath', () => {
@@ -133,6 +133,75 @@ describe('utils', () => {
 			await runner('gb2312', '你好，李磊');
 			await runner('BIG5', '中華人民共和國');
 			await runner('GB18030', '대한민국|中華人民共和國|にっぽんこく、にほんこく');
+		});
+	});
+
+	describe('evalCode', () => {
+
+		it ('should eval script correctly', () => {
+			const logSpyInstance = jest.spyOn(console, 'log');
+			logSpyInstance.mockImplementation(jest.fn());
+
+			const evalCache = {};
+			const expectCode = 'console.log("hello")';
+			const scriptSrc = `<script>${expectCode}</script>`;
+			evalCode(scriptSrc, expectCode, evalCache);
+
+			expect(logSpyInstance).toHaveBeenCalledTimes(1);
+			expect(logSpyInstance).toHaveBeenCalledWith('hello');
+
+			logSpyInstance.mockRestore();
+		});
+
+		it ('should eval script once but exec code twice when cache hit', () => {
+			const evalSpyInstance = jest.spyOn(window, 'eval');
+			const logSpyInstance = jest.spyOn(console, 'log');
+			logSpyInstance.mockImplementation(jest.fn());
+
+			const evalCache = {};
+			const expectCode = 'console.log("hello")';
+			const scriptSrc1 = `<script>${expectCode}</script>`;
+			const scriptSrc2 = `<script>${expectCode}</script>`;
+
+			evalCode(scriptSrc1, expectCode, evalCache);
+			evalCode(scriptSrc2, expectCode, evalCache);
+
+			//use cache, eval once
+			expect(evalSpyInstance).toHaveBeenCalledTimes(1);
+			//exec code twice by cache function
+			expect(logSpyInstance).toHaveBeenCalledTimes(2);
+
+			evalSpyInstance.mockRestore();
+			logSpyInstance.mockRestore();
+		});
+
+		it ('should eval script twice and exec code twice when cache not hit', () => {
+			const evalSpyInstance = jest.spyOn(window, 'eval');
+			const logSpyInstance = jest.spyOn(console, 'log');
+			const infoSpyInstance = jest.spyOn(console, 'info');
+
+			logSpyInstance.mockImplementation(jest.fn());
+			infoSpyInstance.mockImplementation(jest.fn());
+
+			const evalCache = {};
+			const expectCode1 = 'console.log("hello")';
+			const expectCode2 = 'console.info("hello")';
+
+			const scriptSrc1 = `<script>${expectCode1}</script>`;
+			const scriptSrc2 = `<script>${expectCode2}</script>`;
+
+			evalCode(scriptSrc1, expectCode1, evalCache);
+			evalCode(scriptSrc2, expectCode2, evalCache);
+
+			//not use cache, eval twice
+			expect(evalSpyInstance).toHaveBeenCalledTimes(2);
+
+			//exec code by no cache twice
+			expect(logSpyInstance).toHaveBeenCalledTimes(1);
+			expect(infoSpyInstance).toHaveBeenCalledTimes(1);
+
+			evalSpyInstance.mockRestore();
+			logSpyInstance.mockRestore();
 		});
 	});
 });

--- a/src/__tests__/test-utils.js
+++ b/src/__tests__/test-utils.js
@@ -142,10 +142,9 @@ describe('utils', () => {
 			const logSpyInstance = jest.spyOn(console, 'log');
 			logSpyInstance.mockImplementation(jest.fn());
 
-			const evalCache = {};
 			const expectCode = 'console.log("hello")';
 			const scriptSrc = `<script>${expectCode}</script>`;
-			evalCode(scriptSrc, expectCode, evalCache);
+			evalCode(scriptSrc, expectCode);
 
 			expect(logSpyInstance).toHaveBeenCalledTimes(1);
 			expect(logSpyInstance).toHaveBeenCalledWith('hello');
@@ -158,13 +157,12 @@ describe('utils', () => {
 			const logSpyInstance = jest.spyOn(console, 'log');
 			logSpyInstance.mockImplementation(jest.fn());
 
-			const evalCache = {};
-			const expectCode = 'console.log("hello")';
+			const expectCode = 'console.log("hello, China")';
 			const scriptSrc1 = `<script>${expectCode}</script>`;
 			const scriptSrc2 = `<script>${expectCode}</script>`;
 
-			evalCode(scriptSrc1, expectCode, evalCache);
-			evalCode(scriptSrc2, expectCode, evalCache);
+			evalCode(scriptSrc1, expectCode);
+			evalCode(scriptSrc2, expectCode);
 
 			//use cache, eval once
 			expect(evalSpyInstance).toHaveBeenCalledTimes(1);
@@ -183,15 +181,14 @@ describe('utils', () => {
 			logSpyInstance.mockImplementation(jest.fn());
 			infoSpyInstance.mockImplementation(jest.fn());
 
-			const evalCache = {};
-			const expectCode1 = 'console.log("hello")';
-			const expectCode2 = 'console.info("hello")';
+			const expectCode1 = 'console.log("hello, friend")';
+			const expectCode2 = 'console.info("hello, friend")';
 
 			const scriptSrc1 = `<script>${expectCode1}</script>`;
 			const scriptSrc2 = `<script>${expectCode2}</script>`;
 
-			evalCode(scriptSrc1, expectCode1, evalCache);
-			evalCode(scriptSrc2, expectCode2, evalCache);
+			evalCode(scriptSrc1, expectCode1);
+			evalCode(scriptSrc2, expectCode2);
 
 			//not use cache, eval twice
 			expect(evalSpyInstance).toHaveBeenCalledTimes(2);

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ import {
 const styleCache = {};
 const scriptCache = {};
 const embedHTMLCache = {};
-const evalCache = {};
+
 if (!window.fetch) {
 	throw new Error('[import-html-entry] Here is no "fetch" on the window env, you need to polyfill it');
 }
@@ -163,7 +163,7 @@ export function execScripts(entry, scripts, proxy = window, opts = {}) {
 				const rawCode = beforeExec(inlineScript, scriptSrc) || inlineScript;
 				const code = getExecutableScript(scriptSrc, rawCode, proxy, strictGlobal);
 
-				evalCode(scriptSrc, code, evalCache);
+				evalCode(scriptSrc, code);
 
 				afterExec(inlineScript, scriptSrc);
 			};

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@
 import processTpl, { genLinkReplaceSymbol, genScriptReplaceSymbol } from './process-tpl';
 import {
 	defaultGetPublicPath,
+	evalCode,
 	getGlobalProp,
 	getInlineCode,
 	noteGlobalProps,
@@ -162,15 +163,7 @@ export function execScripts(entry, scripts, proxy = window, opts = {}) {
 				const rawCode = beforeExec(inlineScript, scriptSrc) || inlineScript;
 				const code = getExecutableScript(scriptSrc, rawCode, proxy, strictGlobal);
 
-				const key = scriptSrc + rawCode.length;
-				if (!evalCache[key]) {
-					const evalCode = `window.__TEMP_EVAL_FUNC__ = function(){${code}}`;
-					(0, eval)(evalCode);
-					evalCache[key]= window.__TEMP_EVAL_FUNC__;
-					window.__TEMP_EVAL_FUNC__ = null;
-				}
-				const evalFunc = evalCache[key];
-				evalFunc.call(window);
+				evalCode(scriptSrc, code, evalCache);
 
 				afterExec(inlineScript, scriptSrc);
 			};

--- a/src/utils.js
+++ b/src/utils.js
@@ -167,8 +167,10 @@ export function readResAsString(response, autoDetectCharset) {
 		}));
 }
 
-export function evalCode(scriptSrc, code, evalCache = {}) {
-	const key = scriptSrc + code.length;
+const evalCache = {};
+
+export function evalCode(scriptSrc, code) {
+	const key = scriptSrc;
 	if (!evalCache[key]) {
 		const functionWrappedCode = `window.__TEMP_EVAL_FUNC__ = function(){${code}}`;
 		(0, eval)(functionWrappedCode);

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,7 +175,7 @@ export function evalCode(scriptSrc, code) {
 		const functionWrappedCode = `window.__TEMP_EVAL_FUNC__ = function(){${code}}`;
 		(0, eval)(functionWrappedCode);
 		evalCache[key] = window.__TEMP_EVAL_FUNC__;
-		window.__TEMP_EVAL_FUNC__ = null;
+		delete window.__TEMP_EVAL_FUNC__;
 	}
 	const evalFunc = evalCache[key];
 	evalFunc.call(window);

--- a/src/utils.js
+++ b/src/utils.js
@@ -166,3 +166,15 @@ export function readResAsString(response, autoDetectCharset) {
 			reader.readAsText(file, charset);
 		}));
 }
+
+export function evalCode(scriptSrc, code, evalCache = {}) {
+	const key = scriptSrc + code.length;
+	if (!evalCache[key]) {
+		const functionWrappedCode = `window.__TEMP_EVAL_FUNC__ = function(){${code}}`;
+		(0, eval)(functionWrappedCode);
+		evalCache[key] = window.__TEMP_EVAL_FUNC__;
+		window.__TEMP_EVAL_FUNC__ = null;
+	}
+	const evalFunc = evalCache[key];
+	evalFunc.call(window);
+}


### PR DESCRIPTION
I found a problem before is that the eval function will exec each time although the code is same.

So I use a `evalCache` to record the function of the eval code result, then we just need to exec the function, no longer to exec eval more than once。

I use qiankun to test 30 microApps, which has same scripts, then open microApp faster,and memory is lower, you can see the heap is one third of what it was before.
### before
![image](https://user-images.githubusercontent.com/30283441/119264358-6b920980-bc15-11eb-9dc1-b630164888a2.png)

### now
![image](https://user-images.githubusercontent.com/30283441/119264345-5b7a2a00-bc15-11eb-9423-eaab38362812.png)
