### PR TITLE
fix: config entry should return the expect html template when using inline styles

### DIFF
--- a/src/__tests__/test-config-entry.js
+++ b/src/__tests__/test-config-entry.js
@@ -27,3 +27,16 @@ test('config entry should return the expect html template with fetch option', as
 	});
 	expect(template).toBe('<style>/* http://kuitos.me/umi.css */http://kuitos.me/umi.css</style><style>/* http://kuitos.me/test.css */http://kuitos.me/test.css</style><main>config entry test</main><!--  script http://kuitos.me/umi.js replaced by import-html-entry --><!--  script http://kuitos.me/test.js replaced by import-html-entry -->');
 });
+
+test('config entry should return the expect html template when using inline styles', async () => {
+	const config = {
+		styles: ['<style>body {color: #fff}</style>'],
+		scripts: [],
+		html: '<main>config entry test</main>',
+	};
+
+	const { template } = await importEntry(config, { fetch: async url => ({ text: async () => url }) });
+	expect(template).toBe('<style>body {color: #fff}</style><main>config entry test</main>');
+})
+
+

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function getEmbedHTML(template, styles, opts = {}) {
 	return getExternalStyleSheets(styles, fetch)
 		.then(styleSheets => {
 			embedHTML = styles.reduce((html, styleSrc, i) => {
-				html = html.replace(genLinkReplaceSymbol(styleSrc), `<style>/* ${styleSrc} */${styleSheets[i]}</style>`);
+				html = html.replace(genLinkReplaceSymbol(styleSrc), isInlineCode(styleSrc) ? `${styleSrc}` : `<style>/* ${styleSrc} */${styleSheets[i]}</style>`);
 				return html;
 			}, embedHTML);
 			return embedHTML;


### PR DESCRIPTION
```
entry: {
  ...,
  styles: ['<style>body { color: #fff }</style>']
}
```
会被转成 

```
<style>/* <style>body {color: #fff}</style> */body {color: #fff}</style>
```
前面的style标签提前闭合，导致显示错误（<style>/* <style>body {color: #fff}</style>）

