### PR TITLE
fix: 针对 with 造成的性能低下，利用作用域缓存，性能和原生一致

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,8 +59,9 @@ function getExecutableScript(scriptSrc, scriptText, proxy, strictGlobal) {
 	const globalWindow = (0, eval)('window');
 	globalWindow.proxy = proxy;
 	// TODO 通过 strictGlobal 方式切换 with 闭包，待 with 方式坑趟平后再合并
+	var globalKeyToBeCached = 'document,window,self,globalThis,Array,Object,String,Boolean,Math,Number,Symbol,Date,Promise,Function,Proxy,WeakMap,WeakSet,Set,Map,Reflect,Element,Node,Document,RegExp,Error,TypeError,JSON,isNaN,parseFloat,parseInt,performance,console,decodeURI,encodeURI,decodeURIComponent,encodeURIComponent,location,navigator,undefined'
 	return strictGlobal
-		? `;(function(window, self, globalThis){with(window){;${scriptText}\n${sourceUrl}}}).bind(window.proxy)(window.proxy, window.proxy, window.proxy);`
+		? `;(function(window, self, globalThis){with(window){(function(${globalKeyToBeCached}){;${scriptText}\n${sourceUrl}}).call(window, ${globalKeyToBeCached})}}).bind(window.proxy)(window.proxy, window.proxy, window.proxy);`
 		: `;(function(window, self, globalThis){;${scriptText}\n${sourceUrl}}).bind(window.proxy)(window.proxy, window.proxy, window.proxy);`;
 }
 


### PR DESCRIPTION
解决 qiankun 内嵌应用的性能问题，问题来源：https://github.com/umijs/qiankun/issues/1175

基于问题来源提供的测试仓库，针对 1000 个 dom 的创建，性能测试如下：

1. 子应用单独运行：51.432861328125 ms
2. 主应用中运行：646.0361328125 ms
3. 主应用中运行（加入缓存）：47.72412109375 ms