### PR TITLE
docs: add FAQ chapter to explain the issue caused by deferred scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ importHTML('./subApp/index.html')
             const { observable } = mobx;
             observable({
                 name: 'kuitos'
-            })	
+            })
         })
 });
 ```
@@ -204,3 +204,11 @@ execScripts(
     }
 );
 ```
+
+## FAQ
+
+### Why is the resolved value of `execScripts` different from my expectation (e.g. `{}` / `null` / other values)?
+
+The `execScripts` will return the last property on `window` or `proxy window` which is set by the entry script. If the html entry has more than one script that is deferred, the resolved value of `execScripts` will be the value set by the last script, which may not be as expected.
+
+To solve this problem, make sure the entry script is the last in the html entry. For example, if you are using `html-webpack-plugin`, you can set `scriptLoading: 'blocking'` in the plugin options.


### PR DESCRIPTION
The "deferred" mode of some bundlers (e.g. `html-webpack-plugin`) may change the order of `<script>` tag in HTML entry, which can cause `execScripts` to resolve a wrong value. This can't be solved by this library itself, so I added an FAQ chapter to explain this issue and help developers avoid it.

一些打包器（例如 `html-webpack-plugin`）的 deferred 模式可能会改变 HTML entry 内 `<script>` 标签的顺序，导致 `execScripts` 解析出一个错误的值。这无法通过本项目来解决，所以我添加了 FAQ 章节来解释这个问题，以及帮助开发者避免它。