### PR TITLE
fix: schedule should always resolve

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -238,6 +238,8 @@ export function execScripts(entry, scripts, proxy = window, opts = {}) {
 					} else {
 						schedule(i + 1, resolvePromise);
 					}
+				} else {
+					resolvePromise();
 				}
 			}
 


### PR DESCRIPTION
在一些罕见的特殊场景下，i 可能大于等于 scripts.length（由于保密原因，暂时无法提供最小代码仓库），造成 promise 一直处于 pending 状态，引发微前端“白屏”。

```js
function schedule(i, resolvePromise) {
      if (i < scripts.length) {
        var scriptSrc = scripts[i];
        var inlineScript = scriptsText[i];
        exec(scriptSrc, inlineScript, resolvePromise);
```