### PR TITLE
麻烦支持入口js抛错误不影响后续js 执行，与浏览器执行逻辑一致

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,7 @@ export function execScripts(entry, scripts, proxy = window, opts = {}) {
 		}, afterExec = () => {
 		},
 		scopedGlobalVariables = [],
+		entryThrowNonBlock = false,
 	} = opts;
 
 	return getExternalScripts(scripts, fetch)
@@ -194,7 +195,11 @@ export function execScripts(entry, scripts, proxy = window, opts = {}) {
 					} catch (e) {
 						// entry error must be thrown to make the promise settled
 						console.error(`[import-html-entry]: error occurs while executing entry script ${scriptSrc}`);
-						throw e;
+						if(entryThrowNonBlock){
+							throwNonBlockingError(e, `[import-html-entry]: error occurs while executing entry script ${scriptSrc}`);
+						}else{
+							throw e;
+						}
 					}
 				} else {
 					if (typeof inlineScript === 'string') {


### PR DESCRIPTION
诉求：保持和浏览器html中js执行逻辑一致，就算入口js执行报错不影响后续js执行，麻烦支持入口js抛错误不影响后续js 执行，
处理：opt增加entryThrowNonBlock默认false ，默认与现有逻辑一致，特殊需求者开启为true 
背景：集成一个项目，这个项目入口js后续的js会做一些异常的补救和采集